### PR TITLE
TCK-20260309-103 Add PR comment gate

### DIFF
--- a/.github/workflows/pr-comment-gate.yml
+++ b/.github/workflows/pr-comment-gate.yml
@@ -1,0 +1,102 @@
+name: PR Comment Gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-comment-gate:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block merge when review threads are unresolved
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber =
+              context.payload.pull_request?.number ||
+              context.payload.pull_request_review_thread?.pull_request_url?.split('/').pop();
+
+            if (!pullNumber) {
+              core.setFailed('Unable to determine pull request number for pr-comment-gate.');
+              return;
+            }
+
+            const query = `
+              query($owner: String!, $repo: String!, $pullNumber: Int!, $after: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pullNumber) {
+                    number
+                    url
+                    reviewThreads(first: 100, after: $after) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        isResolved
+                        path
+                        line
+                        comments(first: 1) {
+                          nodes {
+                            url
+                            body
+                            author { login }
+                            createdAt
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            let unresolved = [];
+            let after = null;
+
+            while (true) {
+              const res = await github.graphql(query, {
+                owner,
+                repo,
+                pullNumber: Number(pullNumber),
+                after,
+              });
+
+              const pr = res.repository.pullRequest;
+              const threads = pr.reviewThreads.nodes || [];
+
+              for (const thread of threads) {
+                if (!thread.isResolved) {
+                  unresolved.push(thread);
+                }
+              }
+
+              const pageInfo = pr.reviewThreads.pageInfo;
+              if (!pageInfo.hasNextPage) {
+                break;
+              }
+              after = pageInfo.endCursor;
+            }
+
+            if (unresolved.length > 0) {
+              const details = unresolved.slice(0, 20).map((thread, index) => {
+                const c = thread.comments.nodes[0];
+                const where = thread.path ? `${thread.path}${thread.line ? `:${thread.line}` : ''}` : 'unknown location';
+                const author = c?.author?.login || 'unknown';
+                const url = c?.url || '';
+                return `${index + 1}. ${where} by @${author}${url ? ` -> ${url}` : ''}`;
+              }).join('\n');
+
+              core.setFailed(
+                `Found ${unresolved.length} unresolved review thread(s). Resolve all PR conversations before merge.\n${details}`
+              );
+              return;
+            }
+
+            core.info('No unresolved review threads found. pr-comment-gate passed.');

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -29,6 +29,25 @@ To manually run the gate on your staged changes:
 ./scripts/agent_gate.sh --staged
 ```
 
+## Enforce PR Comment Closure Before Merge (Required)
+
+To hard-block merges with unresolved PR conversations:
+
+1. Enable branch protection on `main`:
+   - `Require a pull request before merging`
+   - `Require approvals` (recommended: at least 1)
+   - `Dismiss stale approvals when new commits are pushed`
+   - `Require conversation resolution before merging`
+   - `Require status checks to pass before merging`
+
+2. Mark this check as required:
+   - `PR Comment Gate / pr-comment-gate`
+
+The workflow is defined at:
+- `.github/workflows/pr-comment-gate.yml`
+
+It fails whenever any review thread is unresolved.
+
 ## Playwright Camera Modes
 
 This repo now uses two explicit browser modes for camera flows:

--- a/docs/WORKLOG_ADDENDUM_v4.md
+++ b/docs/WORKLOG_ADDENDUM_v4.md
@@ -1210,3 +1210,32 @@ Review findings:
 
 Review recommendation:
 - `APPROVE`
+
+## TCK-20260309-103 :: Add Hard PR Comment Closure Gate
+
+Type: `DEVOPS_HARDENING`
+Owner: Pranay (human owner, agent execution by Codex)
+Created: 2026-03-09
+Status: `DONE`
+Priority: `P0`
+
+Scope contract:
+- In-scope: Add a GitHub Action gate that fails when PR review threads are unresolved and document required branch-protection setup.
+- Out-of-scope: Retroactively re-running old merged PR checks.
+- Behavior change allowed: `YES`
+
+Targets:
+- `.github/workflows/pr-comment-gate.yml`
+- `docs/SETUP.md`
+
+Acceptance criteria:
+- [x] New `pr-comment-gate` workflow exists and runs on PR lifecycle + thread resolution events.
+- [x] Gate fails if unresolved review threads exist.
+- [x] Setup docs include required branch-protection settings and required check name.
+
+Execution log:
+- [2026-03-09 22:35 IST] Added `.github/workflows/pr-comment-gate.yml` using GraphQL review-thread traversal with explicit failure on unresolved threads.
+- [2026-03-09 22:36 IST] Documented branch-protection + required check setup in `docs/SETUP.md`.
+
+Prompt Trace:
+- `prompts/remediation/implementation-v1.6.1.md`


### PR DESCRIPTION
Summary:
- add PR Comment Gate workflow to fail when review threads are unresolved
- trigger gate on PR updates and thread resolve/unresolve events
- document required branch-protection settings and required check name

Verification:
- local commit hooks passed
- workflow file added at .github/workflows/pr-comment-gate.yml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Action to block merges when any PR review thread is unresolved. Implements the hard PR comment closure gate requested in TCK-20260309-103.

- **New Features**
  - Adds `PR Comment Gate` workflow at `.github/workflows/pr-comment-gate.yml` that fails if unresolved review threads exist, runs on PR updates and thread resolve/unresolve events, and skips drafts.
  - Updates `docs/SETUP.md` with required branch protection settings and the required status check name: `PR Comment Gate / pr-comment-gate`.

<sup>Written for commit 77c5b19618f2c31f8d15031013fb076bf162985f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

