### PR TITLE
Remediate Scorecard findings with immutable pins and CI hardening

### DIFF
--- a/.agent/SESSION_CONTEXT.md
+++ b/.agent/SESSION_CONTEXT.md
@@ -1,6 +1,6 @@
 # Session Context
 
-- Generated: 2026-03-11T07:36:24Z
+- Generated: 2026-03-11T10:21:06Z
 - Project: `learning_for_kids`
 - Provider: `local`
 - Model: `BAAI/bge-base-en-v1.5`
@@ -12,37 +12,37 @@
 ### Architecture Decisions
 - Collection: `projects_proj_learning_for_kids`
 - Query: `architecture decisions for learning_for_kids`
-_Search timed out. Retry when Ollama/Milvus are less busy._
+_Fast mode (--skip-index): retrieval skipped to keep startup non-blocking. Run `/Users/pranay/Projects/agent-start --project learning_for_kids` for full retrieval, or set `AGENT_START_SKIP_INDEX_RETRIEVE=1` if you want retrieval with skip-index._
 
 ### Project Management Workflow
 - Collection: `projects_proj_learning_for_kids`
 - Query: `project management workflow for learning_for_kids`
-_Search timed out. Retry when Ollama/Milvus are less busy._
+_Fast mode (--skip-index): retrieval skipped to keep startup non-blocking. Run `/Users/pranay/Projects/agent-start --project learning_for_kids` for full retrieval, or set `AGENT_START_SKIP_INDEX_RETRIEVE=1` if you want retrieval with skip-index._
 
 ### Known Issues and Worklogs
 - Collection: `projects_proj_learning_for_kids`
 - Query: `known issues and worklog for learning_for_kids`
-_Search timed out. Retry when Ollama/Milvus are less busy._
+_Fast mode (--skip-index): retrieval skipped to keep startup non-blocking. Run `/Users/pranay/Projects/agent-start --project learning_for_kids` for full retrieval, or set `AGENT_START_SKIP_INDEX_RETRIEVE=1` if you want retrieval with skip-index._
 
 ### Prompts and Guidelines
 - Collection: `projects_proj_learning_for_kids`
 - Query: `prompts and guidelines for learning_for_kids`
-_Search timed out. Retry when Ollama/Milvus are less busy._
+_Fast mode (--skip-index): retrieval skipped to keep startup non-blocking. Run `/Users/pranay/Projects/agent-start --project learning_for_kids` for full retrieval, or set `AGENT_START_SKIP_INDEX_RETRIEVE=1` if you want retrieval with skip-index._
 
 ## Shared Cross-Project Retrieval
 
 ### Reusable Patterns
 - Collection: `projects_workspace_shared`
 - Query: `similar architecture patterns for learning_for_kids`
-_Search timed out. Retry when Ollama/Milvus are less busy._
+_Fast mode (--skip-index): retrieval skipped to keep startup non-blocking. Run `/Users/pranay/Projects/agent-start --project learning_for_kids` for full retrieval, or set `AGENT_START_SKIP_INDEX_RETRIEVE=1` if you want retrieval with skip-index._
 
 ### Process Templates
 - Collection: `projects_workspace_shared`
 - Query: `project management templates and workflows`
-_Search timed out. Retry when Ollama/Milvus are less busy._
+_Fast mode (--skip-index): retrieval skipped to keep startup non-blocking. Run `/Users/pranay/Projects/agent-start --project learning_for_kids` for full retrieval, or set `AGENT_START_SKIP_INDEX_RETRIEVE=1` if you want retrieval with skip-index._
 
 ### Common Failure Modes
 - Collection: `projects_workspace_shared`
 - Query: `lessons learned mistakes retrospectives postmortems`
-_Search timed out. Retry when Ollama/Milvus are less busy._
+_Fast mode (--skip-index): retrieval skipped to keep startup non-blocking. Run `/Users/pranay/Projects/agent-start --project learning_for_kids` for full retrieval, or set `AGENT_START_SKIP_INDEX_RETRIEVE=1` if you want retrieval with skip-index._
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.13'
   NODE_VERSION: '22'
@@ -33,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -68,10 +71,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -109,19 +112,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push backend
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./src/backend
           push: true
@@ -130,7 +133,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push frontend
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./src/frontend
           push: true

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-comment-gate.yml
+++ b/.github/workflows/pr-comment-gate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Block merge when review threads are unresolved
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/pr-link-gate.yml
+++ b/.github/workflows/pr-link-gate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate linked issue and TCK in PR body
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const body = context.payload.pull_request?.body || "";

--- a/.github/workflows/project-and-issue-automation.yml
+++ b/.github/workflows/project-and-issue-automation.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add issue or PR to GitHub Project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: ${{ vars.PROJECT_URL }}
           github-token: ${{ secrets.PROJECT_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update linked issue status labels from PR lifecycle
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const body = context.payload.pull_request?.body || "";

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub code scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,14 +21,14 @@ jobs:
       TRIVY_EXIT_CODE: ${{ github.event_name == 'pull_request' && '0' || '1' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Trivy filesystem scan (vuln + misconfig + secrets)
         run: |
           docker run --rm \
             -v "$PWD:/src" \
             -w /src \
-            aquasec/trivy:0.56.2 fs \
+            aquasec/trivy:0.56.2@sha256:26245f364b6f5d223003dc344ec1eb5eb8439052bfecb31d79aeba0c74344b3a fs \
             --config .github/trivy/trivy.yaml \
             --output trivy-results.sarif \
             --exit-code "${TRIVY_EXIT_CODE}" \
@@ -36,6 +36,6 @@ jobs:
 
       - name: Upload SARIF to GitHub code scanning
         if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
         with:
           sarif_file: trivy-results.sarif

--- a/docs/WORKLOG_ADDENDUM_CI_SECURITY_CONFIG_2026-03-11.md
+++ b/docs/WORKLOG_ADDENDUM_CI_SECURITY_CONFIG_2026-03-11.md
@@ -52,3 +52,55 @@ Status updates:
 - [2026-03-11 16:05 IST] **IN PROGRESS** — Configuration changes applied; running staged gate and final verification next.
 - [2026-03-11 16:14 IST] **IN PROGRESS** — Artifact-driven Trivy noise remediation applied; pending CI/code-scanning refresh to verify Security tab is clean.
 - [2026-03-11 16:23 IST] **IN PROGRESS** — CodeQL signal-to-noise hardening applied; pending CodeQL rerun on main to confirm alert volume reduction.
+
+### TCK-20260311-008 :: Scorecard Alert Remediation (Pinned Dependencies + Workflow Permissions)
+
+Ticket Stamp: STAMP-20260311T161900Z-codex-scorecard-remediation
+
+Type: TOOLING
+Owner: Pranay (execution: Codex)
+Created: 2026-03-11
+Status: **IN PROGRESS**
+Priority: P1
+
+Scope contract:
+
+- In-scope: remediate repository-fixable Scorecard findings by pinning workflow actions to immutable SHAs, tightening workflow token permissions, and pinning floating dependency references in Docker/scripts.
+- Out-of-scope: organization settings controls (branch protection policy, review policy) and ecosystem-level scorecard checks that do not map to repo content.
+- Behavior change allowed: YES (CI and tooling behavior only; runtime app behavior unchanged).
+
+Targets:
+
+- Repo: learning_for_kids
+- Files:
+  - `.github/workflows/*.yml` (action pinning + permissions hardening)
+  - `src/backend/Dockerfile`
+  - `src/frontend/Dockerfile`
+  - `scripts/setup.sh`
+  - `scripts/run-e2e.sh`
+  - `evaluations/run-angel-evaluation.sh`
+
+Acceptance Criteria:
+
+- [ ] All mutable workflow action refs (`@v*`) are replaced with pinned commit SHAs.
+- [ ] Deploy workflow has explicit least-privilege token permissions.
+- [ ] Floating base container tags are pinned to immutable digests.
+- [ ] Script-level unpinned dependency installs are upgraded to pinned installs where feasible.
+- [ ] Local staged gate passes without overrides.
+
+Prompt Trace:
+
+- prompts/review/local-pre-commit-review-v1.0.md
+Prompt Trace: prompts/review/local-pre-commit-review-v1.0.md
+
+Execution log:
+
+- [2026-03-11 16:27 IST] Queried open code-scanning totals and confirmed current Security tab composition is `103` total (`59 CodeQL`, `44 Scorecard`). | Evidence: `gh api repos/pranaysuyash/advay-learning/code-scanning/alerts?state=open`
+- [2026-03-11 16:30 IST] Resolved current immutable commit SHAs for all workflow actions in use and replaced mutable refs in workflows (`checkout`, `setup-*`, `github-script`, `codeql-action`, `docker/*`, `add-to-project`). | Evidence: `.github/workflows/*.yml`
+- [2026-03-11 16:33 IST] Added explicit top-level `permissions` to deploy workflow for least privilege (`contents: read`). | Evidence: `.github/workflows/deploy.yml`
+- [2026-03-11 16:36 IST] Pinned container image references in backend/frontend Dockerfiles and Trivy scan image to immutable digests. | Evidence: `src/backend/Dockerfile`, `src/frontend/Dockerfile`, `.github/workflows/trivy.yml`
+- [2026-03-11 16:38 IST] Replaced unpinned dependency install patterns in scripts (`uv` installer script and ad-hoc npm installs) with pinned/versioned installs. | Evidence: `scripts/setup.sh`, `scripts/run-e2e.sh`, `evaluations/run-angel-evaluation.sh`
+
+Status updates:
+
+- [2026-03-11 16:39 IST] **IN PROGRESS** — Remediation edits complete; running staged local gate and preparing PR for reviewer re-check.

--- a/evaluations/run-angel-evaluation.sh
+++ b/evaluations/run-angel-evaluation.sh
@@ -21,7 +21,7 @@ cd /Users/pranay/Projects/learning_for_kids
 # Install Playwright if needed
 if ! npx playwright --version > /dev/null 2>&1; then
   echo "📦 Installing Playwright..."
-  npm install @playwright/test --timeout=300000
+  npm install @playwright/test@1.58.2 --timeout=300000 --no-audit --no-fund
 fi
 
 echo "🎬 Running evaluation with Playwright..."

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -27,7 +27,7 @@ fi
 cd "$ROOT_DIR/src/frontend"
 if [ ! -d "node_modules/playwright" ]; then
   echo "[e2e] Installing Playwright browsers..."
-  npm install --no-audit
+  npm ci --no-audit --no-fund
   npx playwright install --with-deps
 else
   echo "[e2e] Playwright appears installed"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,11 +61,11 @@ print_info "Python $PYTHON_VERSION found ✓"
 
 # Check if uv is installed
 print_info "Checking for uv..."
+UV_PINNED_VERSION="0.8.17"
 if ! command -v uv &> /dev/null; then
-    print_warn "uv not found. Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    # Add to PATH for current session
-    export PATH="$HOME/.cargo/bin:$PATH"
+    print_warn "uv not found. Installing pinned uv version ${UV_PINNED_VERSION}..."
+    python3 -m pip install --user "uv==${UV_PINNED_VERSION}"
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 fi
 
 UV_VERSION=$(uv --version)

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:8bc60ca09afaa8ea0d6d1220bde073bacfedd66a4bf8129cbdc8ef0e16c8a952
 
 WORKDIR /app
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS builder
+FROM node:24-alpine@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28ddf1e99dcafdf114 AS builder
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:alpine
+FROM nginx:alpine@sha256:5bad1ddd1ae00bc2cf5d90a6141566cc3f0e05c6deca4106ef04ff5d8a94b280
 
 # Copy built assets
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
This PR remediates repository-fixable Scorecard code-scanning findings without overrides by hardening CI/workflow supply-chain hygiene and pinning mutable dependency references.

## Issues fixed
- Pinned mutable GitHub Actions refs to immutable commit SHAs across workflows
- Added explicit least-privilege `permissions` to deploy workflow
- Pinned container base images and scanner image to immutable digests
- Replaced unpinned install flows in scripts with pinned/versioned installs (`uv==0.8.17`, `@playwright/test@1.58.2`, `npm ci`)

## Tests / checks run
- `./scripts/agent_gate.sh --staged` (pass)
- `cd src/backend && uv run ruff check . && uv run pytest` (pass: 290 passed, 1 skipped)
- `cd src/frontend && npm run lint && npm run type-check && npm run build` (pass)

## Risk assessment
- Low runtime risk: changes are CI/tooling/scripts + Docker pinning only
- Medium maintenance risk: pinned SHAs/digests require periodic refreshes
- No gate overrides used

## Manual validation steps
1. Confirm GitHub Actions still run successfully for `codeql`, `trivy`, `scorecards`, and `deploy` workflows.
2. Verify Security > Code scanning open alert count decreases as new scans complete.
3. Spot-check Docker builds still succeed with pinned base image digests.

Closes #34
TCK-20260311-008


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CI and supply-chain hygiene by pinning mutable refs to immutable versions and adding least‑privilege workflow permissions, reducing Scorecard and code‑scanning noise. Addresses TCK-20260311-008 by remediating repository-fixable findings.

- **Dependencies**
  - Pinned GitHub Actions to commit SHAs: `actions/checkout`, `github/codeql-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/build-push-action`, `actions/add-to-project`, `actions/github-script`.
  - Pinned container bases: `python:3.13-slim`, `node:24-alpine`, `nginx:alpine` to digest-based images.
  - Pinned scanner image `aquasec/trivy:0.56.2` to a digest.
  - Replaced floating installs with versioned ones: `uv==0.8.17`, `@playwright/test@1.58.2`, and `npm ci` with `--no-audit --no-fund`.

- **Refactors**
  - Added explicit least‑privilege `permissions` (`contents: read`) to `deploy.yml`.
  - Kept runtime app behavior unchanged; CI builds, lint, type-check, and tests pass.

<sup>Written for commit e4bbe249c0a4a9fbe02960feb2f337b5674b2c48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

